### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/pypi/pypi-release/pypi_release/pypi_release.py
+++ b/pypi/pypi-release/pypi_release/pypi_release.py
@@ -70,14 +70,14 @@ class S3(object):
         total_sleep_time = interval
         for x in xrange(n):
             if not self.exists(key):
-                print "wait until %s is available in S3..." % key
+                print "wait until {0!s} is available in S3...".format(key)
                 time.sleep(sleep_time)
                 total_sleep_time += sleep_time
                 sleep_time += interval
             else:
                 return
         raise Exception(
-            "%s has not showed up in S3 after %d sec, check it manually." % (key, total_sleep_time))
+            "{0!s} has not showed up in S3 after {1:d} sec, check it manually.".format(key, total_sleep_time))
 
 
 class PackageItem(object):
@@ -96,7 +96,7 @@ def safe_name(name):
 def extract_package_name(path):
     # make sure file exists
     if not os.path.isfile(path):
-        raise Exception("%s does not exist or not a valid file" % path)
+        raise Exception("{0!s} does not exist or not a valid file".format(path))
 
     file_name = os.path.basename(path)
 
@@ -105,16 +105,16 @@ def extract_package_name(path):
         package_name = m.group(1)
         return package_name, file_name
     else:
-        raise Exception("File name %s is not supported!" % file_name)
+        raise Exception("File name {0!s} is not supported!".format(file_name))
 
 
 def generate_index(s3=None, package_name=None, work_dir="/tmp", max_entry=MAX_ENTRY,
                    dry_run=False):
-    work_dir = "%s/%s" % (work_dir, package_name)
+    work_dir = "{0!s}/{1!s}".format(work_dir, package_name)
     # see comments in release.py for the reason why canonical package name is needed
     safe_package_name = safe_name(package_name)
-    s3_index_path = "%s/%s" % (safe_package_name, "index.html")
-    list_rs = s3.list("%s/" % safe_package_name)
+    s3_index_path = "{0!s}/{1!s}".format(safe_package_name, "index.html")
+    list_rs = s3.list("{0!s}/".format(safe_package_name))
     entries = []
 
     # loop on the S3 list resultset and populate entries
@@ -126,7 +126,7 @@ def generate_index(s3=None, package_name=None, work_dir="/tmp", max_entry=MAX_EN
                                        key.size))
 
     if not entries:
-        print "Package %s has never been released, exit!" % package_name
+        print "Package {0!s} has never been released, exit!".format(package_name)
         return
 
     # sort the list based on object last_modified
@@ -136,8 +136,8 @@ def generate_index(s3=None, package_name=None, work_dir="/tmp", max_entry=MAX_EN
     if not os.path.exists(work_dir):
         os.makedirs(work_dir)
 
-    old = '%s/%s' % (work_dir, OLD_INDEX_FILENAME)
-    new = '%s/%s' % (work_dir, NEW_INDEX_FILENAME)
+    old = '{0!s}/{1!s}'.format(work_dir, OLD_INDEX_FILENAME)
+    new = '{0!s}/{1!s}'.format(work_dir, NEW_INDEX_FILENAME)
 
     # download index.html if exists, for information only
     if s3.exists(s3_index_path):
@@ -147,7 +147,7 @@ def generate_index(s3=None, package_name=None, work_dir="/tmp", max_entry=MAX_EN
     # S3 objects return in alphabetical order, we will re-order based on last modified time
     with open(new, 'w') as fn:
         top = INDEX_HTML_TOP_TMPL % (package_name, package_name)
-        fn.write("%s\n" % top)
+        fn.write("{0!s}\n".format(top))
 
         # skip the top x entries if exceed max_entry
         start = 0
@@ -157,24 +157,24 @@ def generate_index(s3=None, package_name=None, work_dir="/tmp", max_entry=MAX_EN
             new_entry = NEW_ENTRY_TMPL % (
                 safe_package_name, entries[i].name, entries[i].md5, entries[i].name,
                 entries[i].date, entries[i].size)
-            fn.write("%s\n" % new_entry)
+            fn.write("{0!s}\n".format(new_entry))
 
         fn.write(INDEX_HTML_BOTTOM_TMPL)
 
     if dry_run:
-        print "Dryrun only, otherwise should have no problem to regenerate index for %s" % \
-              package_name
+        print "Dryrun only, otherwise should have no problem to regenerate index for {0!s}".format( \
+              package_name)
         return
 
     # finally upload new index
     s3.upload(s3_index_path, new)
     s3.wait_until_available(s3_index_path)
     if safe_package_name != package_name:
-        s3_original_index_path = "%s/%s" % (package_name, "index.html")
+        s3_original_index_path = "{0!s}/{1!s}".format(package_name, "index.html")
         s3.upload(s3_original_index_path, new)
         s3.wait_until_available(s3_original_index_path)
 
-    print "Successfully re-generated index for package %s" % package_name
+    print "Successfully re-generated index for package {0!s}".format(package_name)
 
 
 def gen_md5(file_path, block_size=2 ** 20):
@@ -190,8 +190,8 @@ def gen_md5(file_path, block_size=2 ** 20):
 
 def generate_new_index(work_dir, package_name, safe_package_name, file_name, file_path,
                        first_package, max_entry):
-    old = '%s/%s' % (work_dir, OLD_INDEX_FILENAME)
-    new = '%s/%s' % (work_dir, NEW_INDEX_FILENAME)
+    old = '{0!s}/{1!s}'.format(work_dir, OLD_INDEX_FILENAME)
+    new = '{0!s}/{1!s}'.format(work_dir, NEW_INDEX_FILENAME)
 
     size = os.path.getsize(file_path)
     date = datetime.datetime.utcnow().isoformat()[:-3] + 'Z'
@@ -202,7 +202,7 @@ def generate_new_index(work_dir, package_name, safe_package_name, file_name, fil
     if first_package:
         with open(new, 'w') as fn:
             top = INDEX_HTML_TOP_TMPL % (package_name, package_name)
-            fn.write("%s\n%s\n%s" % (top, new_entry, INDEX_HTML_BOTTOM_TMPL))
+            fn.write("{0!s}\n{1!s}\n{2!s}".format(top, new_entry, INDEX_HTML_BOTTOM_TMPL))
             return
 
     # copy most of the entries over, append the new entry in the end
@@ -214,29 +214,29 @@ def generate_new_index(work_dir, package_name, safe_package_name, file_name, fil
                 if file_name not in line:
                     entries.append(line)
                 else:
-                    print "Skip the existing entry for %s" % file_name
+                    print "Skip the existing entry for {0!s}".format(file_name)
 
     with open(new, 'w') as fn:
         top = INDEX_HTML_TOP_TMPL % (package_name, package_name)
-        fn.write("%s\n" % top)
+        fn.write("{0!s}\n".format(top))
 
         # skip the top x entries if exceed max_entry
         start = 0
         if 0 < max_entry <= len(entries):
             start = 0 + len(entries) - max_entry + 1
-            print "Entries exceeded max allowed %d, skip the top %d entry" % (max_entry, start)
+            print "Entries exceeded max allowed {0:d}, skip the top {1:d} entry".format(max_entry, start)
 
         for i in xrange(start, len(entries)):
-            fn.write("%s" % entries[i])
+            fn.write("{0!s}".format(entries[i]))
 
-        fn.write("%s\n" % new_entry)
+        fn.write("{0!s}\n".format(new_entry))
         fn.write(INDEX_HTML_BOTTOM_TMPL)
 
 
 def release(s3=None, file_path=None, work_dir="/tmp", max_entry=MAX_ENTRY, dry_run=False,
             force=False):
     package_name, file_name = extract_package_name(file_path)
-    work_dir = "%s/%s" % (work_dir, package_name)
+    work_dir = "{0!s}/{1!s}".format(work_dir, package_name)
 
     # pip 6.0+ will query package in its canonical format, i.e. [a-z0-9\-]+
     # so "pip install X_y" become "pip install x-y", to support this behavior,
@@ -244,15 +244,15 @@ def release(s3=None, file_path=None, work_dir="/tmp", max_entry=MAX_ENTRY, dry_r
     # need to generate 2 entries, one uses original name, one uses canonical name, so that
     # we support both pip 6.0- and pip 6.0+
     safe_package_name = safe_name(package_name)
-    s3_file_path = "%s/%s" % (safe_package_name, file_name)
-    s3_index_path = "%s/%s" % (safe_package_name, "index.html")
+    s3_file_path = "{0!s}/{1!s}".format(safe_package_name, file_name)
+    s3_index_path = "{0!s}/{1!s}".format(safe_package_name, "index.html")
 
     # make sure file not exist in index already
     if not force and s3.exists(s3_file_path):
-        raise Exception("%s existed already, use --force if release again!" % file_name)
+        raise Exception("{0!s} existed already, use --force if release again!".format(file_name))
 
-    old = '%s/%s' % (work_dir, OLD_INDEX_FILENAME)
-    new = '%s/%s' % (work_dir, NEW_INDEX_FILENAME)
+    old = '{0!s}/{1!s}'.format(work_dir, OLD_INDEX_FILENAME)
+    new = '{0!s}/{1!s}'.format(work_dir, NEW_INDEX_FILENAME)
     # make sure dir exists
     if not os.path.exists(work_dir):
         os.makedirs(work_dir)
@@ -260,7 +260,7 @@ def release(s3=None, file_path=None, work_dir="/tmp", max_entry=MAX_ENTRY, dry_r
     # download index.html if exists
     first_package = False
     if not s3.exists(s3_index_path):
-        print "Release %s the first time!" % package_name
+        print "Release {0!s} the first time!".format(package_name)
         first_package = True
     else:
         s3.download(s3_index_path, old)
@@ -270,7 +270,7 @@ def release(s3=None, file_path=None, work_dir="/tmp", max_entry=MAX_ENTRY, dry_r
                        first_package, max_entry)
 
     if dry_run:
-        print "Dryrun only, otherwise should have no problem to release %s" % file_path
+        print "Dryrun only, otherwise should have no problem to release {0!s}".format(file_path)
         return
 
     # finally upload both the package and new index
@@ -281,11 +281,11 @@ def release(s3=None, file_path=None, work_dir="/tmp", max_entry=MAX_ENTRY, dry_r
     s3.upload(s3_index_path, new)
     s3.wait_until_available(s3_index_path)
     if safe_package_name != package_name:
-        s3_original_index_path = "%s/%s" % (package_name, "index.html")
+        s3_original_index_path = "{0!s}/{1!s}".format(package_name, "index.html")
         s3.upload(s3_original_index_path, new)
         s3.wait_until_available(s3_original_index_path)
 
-    print "Successfully released %s" % file_path
+    print "Successfully released {0!s}".format(file_path)
 
 
 def main():


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:runt18:pinrepo?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:runt18:pinrepo?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
